### PR TITLE
Hide links to search results page

### DIFF
--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,6 +1,7 @@
 ---
 title: Search Results
 layout: search
-
+toc_hide: true
+hide_summary: true
 ---
 


### PR DESCRIPTION
This pull request hides links to the search results page from:

- The [section menu](https://www.docsy.dev/docs/adding-content/navigation/#section-menu)
- The home [landing page](https://www.docsy.dev/docs/adding-content/content/#docs-section-landing-pages)