### PR TITLE
Improve top navbar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -212,8 +212,8 @@ enable = false
 
 [[menu.main]]
     name = "Home"
-    weight = 1
-    url = "https://lambdalabs.com/"
+    weight = 10
+    url = "/"
 
 [[menu.main]]
     name = "Support"

--- a/config.toml
+++ b/config.toml
@@ -216,7 +216,7 @@ enable = false
     url = "/"
 
 [[menu.main]]
-    name = "Support"
+    name = "Knowledge Base"
     weight = 60
     url = "https://support.lambdalabs.com/"
 

--- a/config.toml
+++ b/config.toml
@@ -219,8 +219,10 @@ enable = false
     name = "Knowledge Base"
     weight = 60
     url = "https://support.lambdalabs.com/"
+    post = "&nbsp;<i class='fas fa-external-link-alt'></i>"
 
 [[menu.main]]
     name = "Forum"
     weight = 70
     url = "https://deeptalk.lambdalabs.com/"
+    post = "&nbsp;<i class='fas fa-external-link-alt'></i>"

--- a/config.toml
+++ b/config.toml
@@ -221,6 +221,6 @@ enable = false
     url = "https://support.lambdalabs.com/"
 
 [[menu.main]]
-    name = "Deeptalk"
+    name = "Forum"
     weight = 70
     url = "https://deeptalk.lambdalabs.com/"

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -2,10 +2,6 @@
 title: "Lambda Docs"
 linkTitle: "Docs Index"
 type: docs
-weight: 40
-menu:
-  main:
-    weight: 40
 ---
 
 {{% pageinfo %}}


### PR DESCRIPTION
This pull request improves the top navbar. Most significantly, this pull request:

- Changes the **Home** link in the navbar to the site's homepage.

  IMO, visitors expect "home" links to take them to the site's homepage rather than to the organization's home page. (I personally have clicked the **Home** link on several occasions expecting it to take me back to the site homepage. :smiley:)

- Changes the names of links to the names Support team uses for the pages.

- Adds external-link icons to the names of external links. (We've already had someone caught off guard when the links took them to external sites in new tabs.)

@winlambda: Please review this pull request to ensure my changes make sense from a UI perspective. Thank you.