### PR TITLE
Use Lunr for searches

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -127,13 +127,13 @@ github_repo = "https://github.com/LambdaLabs/lambda-docs"
 #github_branch= "main"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "33094387eddf5f511"
+#gcs_engine_id = "33094387eddf5f511"
 
 # Enable Algolia DocSearch
 algolia_docsearch = false
 
 # Enable Lunr.js offline search
-offlineSearch = false
+offlineSearch = true
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = false


### PR DESCRIPTION
This pull request:

- Enables Lunr for searches
- Disables Google Custom Search Engine (which, AFAICT, currently isn't working on the site)

See: https://www.docsy.dev/docs/adding-content/navigation/#configure-local-search-with-lunr