### PR TITLE
Improve Cloud index page

### DIFF
--- a/content/en/cloud/_index.md
+++ b/content/en/cloud/_index.md
@@ -1,8 +1,7 @@
 ---
-title: "Lambda Cloud"
+title: "Lambda GPU Cloud"
 linkTitle: "Cloud"
 type: docs
-weight: 50
 ---
 
 {{% pageinfo %}}

--- a/content/en/cloud/_index.md
+++ b/content/en/cloud/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Lambda GPU Cloud"
 linkTitle: "Cloud"
+description: "Documentation for Lambda GPU Cloud, the #1 cloud provider for high-performance GPUs"
 type: docs
 ---
 

--- a/content/en/cloud/_index.md
+++ b/content/en/cloud/_index.md
@@ -4,9 +4,16 @@ linkTitle: "Cloud"
 description: "Documentation for Lambda GPU Cloud, the #1 cloud provider for high-performance GPUs"
 type: docs
 ---
+{{< imgproc cloud Resize "400x">}}{{< /imgproc >}}
 
-{{% pageinfo %}}
-Documentation about Lambda Cloud
-{{% /pageinfo %}}
+<a href="https://lambdalabs.com/service/gpu-cloud" target="_blank">Lambda GPU Cloud&nbsp;<i class='fas fa-external-link-alt'></i></a>
+provides instant access to high-performance cloud GPUs at the best prices on
+the market.
 
-Welcome to the Lambda Cloud documentation site.
+With Lambda GPU Cloud, you have:
+
+- [TensorFlow](https://www.tensorflow.org/),
+  [JupyterLab](https://jupyter.org/), [PyTorch](https://pytorch.org/), and
+  other popular ML software pre-installed
+- [persistent storage]({{< relref "guides/use-persistent-storage" >}}) to save your datasets and other files
+- root access to your instances via SSH

--- a/content/en/cloud/faq/pause-instance.md
+++ b/content/en/cloud/faq/pause-instance.md
@@ -7,5 +7,5 @@ It currently isn't possible to pause (suspend) your instance rather than
 terminating it. But, this feature is in the works.
 
 Until this feature is implemented, you can use
-[persistent storage](/cloud/guides/use-persistent-storage) to imitate some of
+[persistent storage]({{< relref "../guides/use-persistent-storage" >}}) to imitate some of
 the benefits of being able to pause your instance.


### PR DESCRIPTION
Also, in the [_Can I pause my instance instead of terminating it?_](https://docs.lambdalabs.com/cloud/faq/pause-instance/) FAQ, use a shortcode for the link to the [_Use persistent storage to save datasets and system state_](https://docs.lambdalabs.com/cloud/guides/use-persistent-storage/) guide. The rationale is in [7b56303](https://github.com/LambdaLabs/lambda-docs/pull/28/commits/7b56303b8054983ceb0e97e5c39dd23423c278d4)'s commit message.