### PR TITLE
Add links to blog and YouTube

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -174,20 +174,10 @@ enable = false
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
-  name = "Support"
-  url = "https://support.lambdalabs.com/hc/en-us"
-  icon = "fa fa-comments-question"
-  desc = "Lambda Support"
-[[params.links.user]]
   name ="Twitter"
   url = "https://twitter.com/lambdaapi?lang=en"
   icon = "fab fa-twitter"
   desc = "Follow us on Twitter to get the latest news!"
-[[params.links.user]]
-  name = "Deeptalk"
-  url = "https://deeptalk.lambdalabs.com"
-  icon = "fab fa-comment"
-  desc = "Lambda Forums"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
   name = "GitHub"

--- a/config.toml
+++ b/config.toml
@@ -216,3 +216,15 @@ enable = false
     weight = 70
     url = "https://deeptalk.lambdalabs.com/"
     post = "&nbsp;<i class='fas fa-external-link-alt'></i>"
+
+[[menu.main]]
+    name = "Blog"
+    weight = 80
+    url = "https://lambdalabs.com/blog/"
+    post = "&nbsp;<i class='fas fa-external-link-alt'></i>"
+
+[[menu.main]]
+    name = "YouTube"
+    weight = 90
+    url = "https://www.youtube.com/c/LambdaLabs"
+    post = "&nbsp;<i class='fas fa-external-link-alt'></i>"


### PR DESCRIPTION
- Add links to blog and YouTube
- Remove links that, for currently unknown reasons, don't display

NB: The added links crowd the nav bar and make it ugly on mobile. But, given > 90% of visitors are on desktop, I don't think this is a big deal.

Closes: #37