### PR TITLE
Tag article titles and bodies

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,0 +1,20 @@
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	<header class="article-meta">
+		{{ partial "taxonomy_terms_article_wrapper.html" . }}
+		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+			{{ partial "reading-time.html" . }}
+		{{ end }}
+	</header>    
+	{{ .Content }}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+		{{ partial "feedback.html" .Site.Params.ui.feedback }}
+		<br />
+	{{ end }}
+	{{ if (.Site.Params.DisqusShortname) }}
+		<br />
+		{{ partial "disqus-comment.html" . }}
+	{{ end }}
+	{{ partial "page-meta-lastmod.html" . }}
+</div>

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,5 +1,5 @@
 <div class="td-content">
-	<h1>{{ .Title }}</h1>
+	<h1 id="zd-article-title">{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
 		{{ partial "taxonomy_terms_article_wrapper.html" . }}

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -7,7 +7,7 @@
 			{{ partial "reading-time.html" . }}
 		{{ end }}
 	</header>    
-	{{ .Content }}
+        <div id="zd-article-body">{{ .Content }}</div>
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />


### PR DESCRIPTION
This pull request causes article titles and bodies to be "tagged" to make them easier to extract.

For example:

```sh
# Extract "Use iptables to disable firewall" article title.
ARTICLE_URL="https://zd-hc-tags.lambda-docs.pages.dev/cloud/guides/iptables-flush-rules/" && \
curl -s "$ARTICLE_URL" | \
xmllint --html --xpath "string(//h1[@id='zd-article-title'])" - 2>/dev/null
```

```sh
# Extract "Use iptables to disable firewall" article body.
ARTICLE_URL="https://zd-hc-tags.lambda-docs.pages.dev/cloud/guides/iptables-flush-rules/" && \
curl -s "$ARTICLE_URL" | \
xmllint --html --xpath "string(//div[@id='zd-article-body'])" - 2>/dev/null
```

```sh
# Create the body of a Zendesk Help Center article in the JSON needed to
# publish using the Zendesk Help Center API [1].
#
# [1] https://developer.zendesk.com/api-reference/help_center/help-center-api/articles/#create-article
ARTICLE_URL="https://zd-hc-tags.lambda-docs.pages.dev/cloud/guides/iptables-flush-rules/" && \
curl -s "$ARTICLE_URL" | xmllint --html --xpath "//div[@id='zd-article-body']" - 2>/dev/null | \
jq -Rs '{article: {body: .}}'
```