### PR TITLE
Add script to publish docs site articles to the Help Center

### DIFF
--- a/zd_sync
+++ b/zd_sync
@@ -1,0 +1,117 @@
+#!/bin/bash
+# 
+# Publish a docs site[1] article to the Zendesk Help Center[2].
+# 
+# Usage: ./zd_sync [URL] [SECTION]
+# 
+# [URL] is the docs site article URL. For example:
+#       https://docs.lambdalabs.com/cloud/faq/nmi-received-for-unknown-reason/
+# 
+# [SECTION] is the Help Center section in which to publish the article.
+#           SECTION must be one of the following:
+#             - cloud
+#             - linux
+#             - servers
+#             - tensorbook
+#             - windows
+#             - workstations
+# 
+# [1] https://docs.lambdalabs.com/
+# [2] https://support.lambdalabs.com/hc/en-us
+# 
+
+set -e
+
+readonly API_EMAIL=""
+readonly API_TOKEN=""
+readonly API_URL=""
+
+clean_up() {
+  echo "Deleting temporary files…"
+  rm -f "${ARTICLE_FILE}" "${ARTICLE_JSON_FILE}" "${PUBL_ARTICLE_JSON_FILE}"
+  echo "Done."
+}
+
+if [[ "$#" -eq 0 ]]; then
+  echo "No URL or section supplied. Aborting." >&2
+  clean_up
+  exit 1
+fi
+
+if [[ "$#" -eq 1 ]]; then
+  echo "No section supplied. Aborting." >&2
+  clean_up
+  exit 1
+fi
+
+readonly ARTICLE_FILE="$(mktemp)"
+if ! curl --silent "$1" > "${ARTICLE_FILE}"; then
+  echo "Unable to fetch article. Aborting." >&2
+  clean_up
+  exit 1
+fi
+
+case "$2" in
+  "cloud")
+    SECTION=9050648839821
+    ;;
+  "linux")
+    SECTION=9050769494541
+    ;;
+  "servers")
+    SECTION=9050593366285
+    ;;
+  "tensorbook")
+    SECTION=4738754483597
+    ;;
+  "windows")
+    SECTION=4734490996109
+    ;;
+  "workstations")
+    SECTION=9050588728205
+    ;;
+  *)
+    echo "Invalid section. Aborting." >&2
+    clean_up
+    exit 1
+    ;;
+esac
+
+readonly ARTICLE_TITLE="$(xmllint --html --xpath "string(//h1[@id='zd-article-title'])" \
+  - < "${ARTICLE_FILE}" 2> /dev/null)"
+readonly ARTICLE_BODY="$(xmllint --html --xpath "//div[@id='zd-article-body']" \
+  - < "${ARTICLE_FILE}" 2> /dev/null)"
+
+if [[ -z "${ARTICLE_TITLE}" ]] || [[ -z "${ARTICLE_BODY}" ]]; then
+  echo "URL isn't a docs site article. Aborting." >&2
+  clean_up
+  exit 1
+fi
+
+readonly ARTICLE_JSON_FILE="$(mktemp)"
+jq --null-input --arg title "${ARTICLE_TITLE}" --arg body "${ARTICLE_BODY}" \
+    '{
+       "article": {
+         "title": $title,
+         "body": $body,
+         "locale": "en-us",
+         "permission_group_id": 2813452,
+         "user_segment_id": null
+       },
+       "notify_subscribers": false
+     }' > "${ARTICLE_JSON_FILE}"
+
+# TODO: Improve so that if the below command is successful, echo the URL of
+#       the published article.
+readonly PUBL_ARTICLE_JSON_FILE="$(mktemp)"
+curl "${API_URL}/sections/${SECTION}/articles.json" \
+     --silent \
+     --data @"${ARTICLE_JSON_FILE}" \
+     --header "Content-Type: application/json" \
+     --user "${API_EMAIL}/${API_TOKEN}" > "${PUBL_ARTICLE_JSON_FILE}"
+
+echo -e "Article published successfully.\n"
+jq . < "${PUBL_ARTICLE_JSON_FILE}"
+echo -e "\n"
+
+clean_up

--- a/zd_sync
+++ b/zd_sync
@@ -2,6 +2,9 @@
 # 
 # Publish a docs site[1] article to the Zendesk Help Center[2].
 # 
+# **Warning** This script doesn't have much error handling and hasn't been
+# tested much. Use at your own risk.
+# 
 # Usage: ./zd_sync URL SECTION
 # 
 # URL is the docs site article URL. For example:

--- a/zd_sync
+++ b/zd_sync
@@ -2,12 +2,12 @@
 # 
 # Publish a docs site[1] article to the Zendesk Help Center[2].
 # 
-# Usage: ./zd_sync [URL] [SECTION]
+# Usage: ./zd_sync URL SECTION
 # 
-# [URL] is the docs site article URL. For example:
+# URL is the docs site article URL. For example:
 #       https://docs.lambdalabs.com/cloud/faq/nmi-received-for-unknown-reason/
 # 
-# [SECTION] is the Help Center section in which to publish the article.
+# SECTION is the Help Center section in which to publish the article.
 #           SECTION must be one of the following:
 #             - cloud
 #             - linux


### PR DESCRIPTION
The script is useful for publishing articles on the [docs site](https://docs.lambdalabs.com/) to the [Help Center](https://support.lambdalabs.com/hc/en-us).