### PR TITLE
Tag articles

### DIFF
--- a/content/en/cloud/faq/cannot-find-nvidia-cudnn.md
+++ b/content/en/cloud/faq/cannot-find-nvidia-cudnn.md
@@ -1,6 +1,12 @@
 ---
 title: "Why can't my program find the NVIDIA cuDNN library?"
 type: docs
+tags:
+- NVIDIA
+- cuDNN
+- PyTorch
+- TensorFlow
+- Lambda Stack
 ---
 
 Unfortunately, the

--- a/content/en/cloud/faq/failed-payment.md
+++ b/content/en/cloud/faq/failed-payment.md
@@ -1,6 +1,8 @@
 ---
 title: "What happens to my account if I don't pay an invoice?"
 type: docs
+tags:
+- billing
 ---
 
 {{% alert title="Warning" color="warning" %}}

--- a/content/en/cloud/faq/how-do-i-change-my-password.md
+++ b/content/en/cloud/faq/how-do-i-change-my-password.md
@@ -1,6 +1,5 @@
 ---
 title: "How do I change my password?"
-linkTitle: "How do I change my password?"
 type: docs
 ---
 

--- a/content/en/cloud/faq/more-than-one-ssh-key.md
+++ b/content/en/cloud/faq/more-than-one-ssh-key.md
@@ -1,6 +1,8 @@
 ---
 title: "Is it possible to use more than one SSH key?"
 type: docs
+tags:
+- SSH
 ---
 
 It's possible to allow more than one SSH key to access your instance. To do

--- a/content/en/cloud/faq/network-bandwidth.md
+++ b/content/en/cloud/faq/network-bandwidth.md
@@ -1,6 +1,8 @@
 ---
 title: "What network bandwidth does Lambda GPU Cloud provide?"
 type: docs
+tags:
+- network
 ---
 
 All of our [on-demand instances](https://lambdalabs.com/service/gpu-cloud)

--- a/content/en/cloud/faq/on-demand-instance-invoicing.md
+++ b/content/en/cloud/faq/on-demand-instance-invoicing.md
@@ -1,6 +1,8 @@
 ---
 title: "How are on-demand instances invoiced?"
 type: docs
+tags:
+- billing
 ---
 
 [On-demand instances](https://lambdalabs.com/service/gpu-cloud) are billed in

--- a/content/en/cloud/faq/opening-ports.md
+++ b/content/en/cloud/faq/opening-ports.md
@@ -1,6 +1,8 @@
 ---
 title: "Is it possible to open ports other than for SSH?"
 type: docs
+tags:
+- network
 ---
 
 Yes, it's possible to open ports other than for SSH.

--- a/content/en/cloud/faq/pause-instance.md
+++ b/content/en/cloud/faq/pause-instance.md
@@ -1,6 +1,8 @@
 ---
 title: "Can I pause my instance instead of terminating it?"
 type: docs
+tags:
+- storage
 ---
 
 It currently isn't possible to pause (suspend) your instance rather than

--- a/content/en/cloud/faq/problem-processing-payment-method.md
+++ b/content/en/cloud/faq/problem-processing-payment-method.md
@@ -1,6 +1,8 @@
 ---
 title: "Why is my credit or debit card being declined?"
 type: docs
+tags:
+- billing
 ---
 
 Common reasons why credit and debit card transactions are declined include:

--- a/content/en/cloud/faq/recover-data-terminated-instance.md
+++ b/content/en/cloud/faq/recover-data-terminated-instance.md
@@ -2,6 +2,8 @@
 title: "Can my data be recovered once I've terminated my instance?"
 weight: 20
 type: docs
+tags:
+- storage
 ---
 
 {{% alert title="Warning" color="warning" %}}

--- a/content/en/cloud/faq/recover-data-terminated-instance.md
+++ b/content/en/cloud/faq/recover-data-terminated-instance.md
@@ -1,6 +1,5 @@
 ---
 title: "Can my data be recovered once I've terminated my instance?"
-weight: 20
 type: docs
 tags:
 - storage

--- a/content/en/linux/guides/remove-reinstall-lambda-stack.md
+++ b/content/en/linux/guides/remove-reinstall-lambda-stack.md
@@ -1,6 +1,8 @@
 ---
 title: "Remove and reinstall Lambda Stack"
 type: docs
+tags:
+- Lambda Stack
 ---
 
 To remove and reinstall

--- a/content/en/linux/guides/upgrade-software-ubuntu.md
+++ b/content/en/linux/guides/upgrade-software-ubuntu.md
@@ -1,6 +1,8 @@
 ---
 title: "Upgrade software in Ubuntu"
 type: docs
+tags:
+- Ubuntu
 ---
 
 Ubuntu regularly checks for new versions of software installed from an `apt`

--- a/content/en/linux/guides/upgrade-ubuntu-and-lambda-stack.md
+++ b/content/en/linux/guides/upgrade-ubuntu-and-lambda-stack.md
@@ -1,6 +1,9 @@
 ---
 title: "Upgrade Ubuntu and Lambda Stack"
 type: docs
+tags:
+- Ubuntu
+- Lambda Stack
 ---
 
 Follow these instructions to upgrade Ubuntu and

--- a/content/en/tensorbook/guides/fix-brightness-control.md
+++ b/content/en/tensorbook/guides/fix-brightness-control.md
@@ -1,6 +1,8 @@
 ---
 title: "Fix resolution and brightness control on Tensorbook"
 type: docs
+tags:
+- troubleshooting
 ---
 
 1. In a terminal, run the command `sudo prime-select on-demand`. Then, reboot

--- a/content/en/tensorbook/guides/reinstall-lambda-stack.md
+++ b/content/en/tensorbook/guides/reinstall-lambda-stack.md
@@ -1,6 +1,9 @@
 ---
 title: "Reinstall Lambda Stack in Ubuntu on a Tensorbook"
 type: docs
+tags:
+- Lambda Stack
+- Ubuntu
 ---
 
 To reinstall

--- a/content/en/windows/guides/filesystem-check-repair-system-files.md
+++ b/content/en/windows/guides/filesystem-check-repair-system-files.md
@@ -1,6 +1,8 @@
 ---
 title: "Run a filesystem check on Windows and repair system files"
 type: docs
+tags:
+- troubleshooting
 ---
 
 If Windows is freezing or behaving erratically, there might be a problem with

--- a/content/en/windows/guides/msinfo32-gather-information.md
+++ b/content/en/windows/guides/msinfo32-gather-information.md
@@ -1,6 +1,8 @@
 ---
 title: "Gather system information in Windows using MSINFO32"
 type: docs
+tags:
+- troubleshooting
 ---
 
 You can use

--- a/content/en/windows/guides/prevent-incorrect-clock.md
+++ b/content/en/windows/guides/prevent-incorrect-clock.md
@@ -1,6 +1,8 @@
 ---
 title: "Prevent incorrect clock in Windows after booting Ubuntu"
 type: docs
+tags:
+- troubleshooting
 ---
 
 Ubuntu saves the current time to the machine hardware clock in

--- a/content/en/windows/guides/system-info-using-dxdiag.md
+++ b/content/en/windows/guides/system-info-using-dxdiag.md
@@ -1,6 +1,8 @@
 ---
 title: "Gather system information in Windows using DxDiag"
 type: docs
+tags:
+- troubleshooting
 ---
 
 You can use the

--- a/content/en/workstations/faq/upgrade-hardware.md
+++ b/content/en/workstations/faq/upgrade-hardware.md
@@ -1,6 +1,9 @@
 ---
 title: "How do I upgrade my system's GPUs, storage, or other hardware?"
 type: docs
+tags:
+- hardware
+- upgrade
 ---
 
 [Contact the Lambda Support team](mailto:support@lambdalabs.com?subject=Hardware%20upgrade)


### PR DESCRIPTION
This PR adds tags to many, but not all, of the articles. Tags allow visitors to list articles by a tag, regardless of which section (Cloud, Servers, etc.) each article is in.

This PR results in the creation of a "Tag Cloud" at the right-hand side of all pages. The Tag Cloud lists all tags currently being used.