### PR TITLE
Begin work on making homepage product-oriented for support

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -17,20 +17,20 @@ type: docs
 
 ### GPU Cloud
 
-- [Why is my credit or debit card being declined?]({{< relref "cloud/faq/problem-processing-payment-method" >}})
-- [What happens to my account if I don't pay an invoice?]({{< relref "cloud/faq/failed-payment" >}})
-- [Can I pause my instance instead of terminating it?]({{< relref "cloud/faq/pause-instance" >}})
+- [Why is my credit or debit card being declined?]({{< relref "cloud/problem-processing-payment-method" >}})
+- [What happens to my account if I don't pay an invoice?]({{< relref "cloud/failed-payment" >}})
+- [Can I pause my instance instead of terminating it?]({{< relref "cloud/pause-instance" >}})
 
 ### Servers
 
-- [Where can I find my server's IPMI (BMC) password?]({{< relref "servers/faq/ipmi-password" >}})
-- [What regions do you do business in?]({{< relref "servers/faq/business-regions" >}})
+- [Where can I find my server's IPMI (BMC) password?]({{< relref "servers/ipmi-password" >}})
+- [What regions do you do business in?]({{< relref "servers/business-regions" >}})
 
 ### Workstations
 
-- [How do I upgrade my system's GPUs, storage, or other hardware?]({{< relref "workstations/faq/upgrade-hardware" >}})
+- [How do I upgrade my system's GPUs, storage, or other hardware?]({{< relref "workstations/upgrade-hardware" >}})
 
 ### Tensorbook
 
-- [Reinstall Lambda Stack in Ubuntu on a Tensorbook]({{< relref "tensorbook/guides/reinstall-lambda-stack" >}})
-- [Fix resolution and brightness control on Tensorbook]({{< relref "tensorbook/guides/fix-brightness-control" >}})
+- [Reinstall Lambda Stack in Ubuntu on a Tensorbook]({{< relref "tensorbook/reinstall-lambda-stack" >}})
+- [Fix resolution and brightness control on Tensorbook]({{< relref "tensorbook/fix-brightness-control" >}})

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -4,40 +4,33 @@ linkTitle: "Docs Index"
 description: "Guides, FAQs, and other helpful information for Lambda products including GPU Cloud, Echelon, Hyperplane, Scalar, Vector, and Tensorbook"
 type: docs
 ---
+<table>
+  <tr>
+    <td><a href="{{< relref "cloud" >}}">{{< imgproc cloud Resize "200x">}}GPU Cloud{{< /imgproc >}}</a></td>
+    <td><a href="{{< relref "servers" >}}">{{< imgproc hyperplane Resize "200x">}}Servers{{< /imgproc >}}</a></td>
+    <td><a href="{{< relref "workstations" >}}">{{< imgproc vector Resize "200x">}}Workstations{{< /imgproc >}}</a></td>
+    <td><a href="{{< relref "tensorbook" >}}">{{< imgproc tensorbook Resize "200x">}}Tensorbook{{< /imgproc >}}</a></td>
+  </tr>
+</table>
 
-## Welcome to Lambda Docs!
+## Top FAQs
 
-Here you'll find documentation for
-<a href="https://lambdalabs.com/" target="_blank">Lambda&nbsp;<i class='fas fa-external-link-alt'></i></a> products
-including:
+### GPU Cloud
 
-<a href="https://lambdalabs.com/service/gpu-cloud" target="_blank">{{< imgproc cloud Resize "400x">}}GPU Cloud&nbsp;<i class='fas fa-external-link-alt'></i>{{< /imgproc >}}</a>
-<a href="https://lambdalabs.com/gpu-cluster/echelon" target="_blank">{{< imgproc echelon Resize "400x">}}Echelon&nbsp;<i class='fas fa-external-link-alt'></i>{{< /imgproc >}}</a>
-<a href="https://lambdalabs.com/deep-learning/servers/hyperplane-a100" target="_blank">{{< imgproc hyperplane Resize "400x">}}Hyperplane&nbsp;<i class='fas fa-external-link-alt'></i>{{< /imgproc >}}</a>
-<a href="https://lambdalabs.com/products/blade" target="_blank">{{< imgproc scalar Resize "400x">}}Scalar&nbsp;<i class='fas fa-external-link-alt'></i>{{< /imgproc >}}</a>
-<a href="https://lambdalabs.com/gpu-workstations/vector" target="_blank">{{< imgproc vector Resize "400x">}}Vector&nbsp;<i class='fas fa-external-link-alt'></i>{{< /imgproc >}}</a>
-<a href="https://lambdalabs.com/deep-learning/laptops/tensorbook" target="_blank">{{< imgproc tensorbook Resize "400x">}}Tensorbook&nbsp;<i class='fas fa-external-link-alt'></i>{{< /imgproc >}}</a>
+- [Why is my credit or debit card being declined?]({{< relref "cloud/faq/problem-processing-payment-method" >}})
+- [What happens to my account if I don't pay an invoice?]({{< relref "cloud/faq/failed-payment" >}})
+- [Can I pause my instance instead of terminating it?]({{< relref "cloud/faq/pause-instance" >}})
 
-<!-- XXX: We should consider using Docsy's card shortcodes. See:
-          https://www.docsy.dev/docs/adding-content/shortcodes/#card-panes
+### Servers
 
-{{< card header="**GPU Cloud**" >}}
-    Content card 0
-  {{< /card >}}
-  {{< card header="**Echelon**" >}}
-    Content card 1
-  {{< /card >}}
-  {{< card header="**Hyperplane**" >}}
-    Content card 2
-  {{< /card >}}
-  {{< card header="**Scalar**" >}}
-    Content card 3
-  {{< /card >}}
-  {{< card header="**Vector**" >}}
-    Content card 4
-  {{< /card >}}
-  {{< card header="**Tensorbook**" >}}
-    Content card 5
-  {{< /card >}}
+- [Where can I find my server's IPMI (BMC) password?]({{< relref "servers/faq/ipmi-password" >}})
+- [What regions do you do business in?]({{< relref "servers/faq/business-regions" >}})
 
--->
+### Workstations
+
+- [How do I upgrade my system's GPUs, storage, or other hardware?]({{< relref "workstations/faq/upgrade-hardware" >}})
+
+### Tensorbook
+
+- [Reinstall Lambda Stack in Ubuntu on a Tensorbook]({{< relref "tensorbook/guides/reinstall-lambda-stack" >}})
+- [Fix resolution and brightness control on Tensorbook]({{< relref "tensorbook/guides/fix-brightness-control" >}})


### PR DESCRIPTION
This PR improves the homepage to be more product-oriented for support:

- The product images link to the corresponding docs section instead of to marketing pages.
- The top FAQs for each product are prominently displayed.

Closes: #89