### PR TITLE
Make it easier to find recovery images

### DIFF
--- a/content/en/linux/recovery-images.md
+++ b/content/en/linux/recovery-images.md
@@ -34,6 +34,11 @@ downloaded using the following link:
 - [Lambda Recovery for Tensorbook (Jammy)](https://files.lambdalabs.com/recovery/tensorbook-jammy-20221105.iso) (based on Ubuntu 22.04 LTS _jammy_)
 
 {{% alert title="Note" color="info" %}}
+This recovery image is for the _Razer x Lambda Tensorbook_ only and won't work
+on older Tensorbook models.
+{{% /alert %}}
+
+{{% alert title="Note" color="info" %}}
 The recovery images contain software distributed under various licenses,
 including the
 [Software License Agreement (SLA) for NVIDIA cuDNN](https://docs.nvidia.com/deeplearning/cudnn/sla/index.html).

--- a/content/en/tensorbook/tensorbook-recovery-images.md
+++ b/content/en/tensorbook/tensorbook-recovery-images.md
@@ -1,0 +1,10 @@
+---
+title: "Where can I download recovery images for my Tensorbook?"
+type: docs
+tags:
+- troubleshooting
+- recovery
+---
+
+Tensorbook recovery images can be downloaded from our
+[recovery images FAQ]({{< relref "../linux/recovery-images#tensorbook" >}}).

--- a/content/en/workstations/workstation-recovery-images.md
+++ b/content/en/workstations/workstation-recovery-images.md
@@ -1,0 +1,10 @@
+---
+title: "Where can I download recovery images for my workstation?"
+type: docs
+tags:
+- troubleshooting
+- recovery
+---
+
+Workstation recovery images can be downloaded from our
+[recovery images FAQ]({{< relref "../linux/recovery-images#workstations" >}}).


### PR DESCRIPTION
This PR makes it easier to find the [recovery images](https://docs.lambdalabs.com/linux/recovery-images/) by adding a recovery images FAQ under each of:

- the [Tensorbook](https://docs.lambdalabs.com/tensorbook/) section
- the [Workstations](https://docs.lambdalabs.com/workstations/) section

Closes: #104