### PR TITLE
Added docker compose command if repo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,25 +46,21 @@ You should preview your changes locally to make sure they're building as
 expected. The recommended way to preview your changes is to use
 [Docker Compose](https://docs.docker.com/compose/).
 
-Depending on how you installed docker compose, there are two ways to run it.
-If you installed it. If you installed it [manually](https://docs.docker.com/compose/install/linux/#install-the-plugin-manually),
-then run the following while in the directory for your clone of the docs site
-repository:
+You can install Docker Compose in Ubuntu by running:
+
+```bash
+sudo apt-get install docker-compose
+```
+
+Then, while in the directory for your clone of the docs site repository, run:
 
 ```bash
 docker-compose up --build
 ```
 
-If you installed docker compose [using docker's repository](https://docs.docker.com/compose/install/linux/#install-using-the-repository), then run the following
-while in the directory for your clone of the docs site repository:
-
-```bash
-docker compose up --build
-```
-
-Then, in your browser, navigate to http://localhost:1313. You should see a
-local build of the docs site with your changes. The site will automatically
-rebuild each time changes are made.
+In your browser, navigate to http://localhost:1313. You should see a local
+build of the docs site with your changes. The site will automatically rebuild
+each time changes are made.
 
 ## Creating a pull request
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,20 @@ You should preview your changes locally to make sure they're building as
 expected. The recommended way to preview your changes is to use
 [Docker Compose](https://docs.docker.com/compose/).
 
-While in the directory for your clone of the docs site repository, run:
+Depending on how you installed docker compose, there are two ways to run it.
+If you installed it. If you installed it [manually](https://docs.docker.com/compose/install/linux/#install-the-plugin-manually),
+then run the following while in the directory for your clone of the docs site
+repository:
 
 ```bash
 docker-compose up --build
+```
+
+If you installed docker compose [using docker's repository](https://docs.docker.com/compose/install/linux/#install-using-the-repository), then run the following
+while in the directory for your clone of the docs site repository:
+
+```bash
+docker compose up --build
 ```
 
 Then, in your browser, navigate to http://localhost:1313. You should see a


### PR DESCRIPTION
There are two ways to install docker compose, both of which are outlined in the official install pages linked to from README.md. If the manual installation is chosen, a binary file named "docker-compose" is created. If installation from the docker repo is chosen, the "docker-compose-plugin" package is installed, which adds compose as a sub-command for docker, so instead of "docker-compose up", you would type "docker compose up". I feel as though both should be referenced, since both installation options are referenced.