### PR TITLE
Remove instruction to replace INSTANCE-DETAILS with actual filename

### DIFF
--- a/content/en/cloud/launch-instance-api.md
+++ b/content/en/cloud/launch-instance-api.md
@@ -34,6 +34,3 @@ You can launch an instance from the command line using the
 
 Replace **API-KEY** with your actual API key. **Don't remove the trailing
 colon (:).**
-
-Replace **INSTANCE-DETAILS** with the name of the payload file you created in
-the previous step.


### PR DESCRIPTION
This PR removes the instruction to replace **INSTANCE-DETAILS** with the name of the file created to contain the [JSON payload for the /launch endpoint](https://cloud.lambdalabs.com/api/v1/docs#operation/launchInstance).

The instruction is no longer needed because in 16268f58c8fc7eab590d52f0b69bd2863b392b85, the FAQ was modified to explicitly instruct to name the payload file `request.json`.