### PR TITLE
Remove errant duplicate link to Kube AI tutorial

### DIFF
--- a/docs/education/index.md
+++ b/docs/education/index.md
@@ -27,7 +27,6 @@ hide:
 - [Troubleshooting and debugging](linux-usage/troubleshooting-and-debugging.md)
 - [Using the Lambda bug report to troubleshoot your system](linux-usage/using-the-lambda-bug-report-to-troubleshoot-your-system.md)
 - [Using the nvidia-bug-report.log file to troubleshoot your system](linux-usage/using-the-nvidia-bug-report.log-file-to-troubleshoot-your-system.md)
-- [Using KubeAI to deploy Nous Research's Hermes 3 and other LLMs](large-language-models/kubeai-hermes-3.md)
 
 ## Programming
 


### PR DESCRIPTION
## Description

This PR removes an errant duplicate link to the KubeAI tutorial.

## Related issues

None

## Checklist

- [ ] ~~Documentation follows the [contributing guidelines](../CONTRIBUTING.md).~~
- [ ] ~~Documentation linked to in nav and index pages.~~
- [ ] ~~Files used in this PR (e.g., images and PDFs) are committed.~~
- [ ] ~~Link to existing documentation and the reverse.~~
- [x] Changes have been tested locally.
- [x] Reviewers have been assigned (at least 1 tech writer and 1 eng).

## Additional notes

None