### PR TITLE
Fix paths and a link in guest agent docs

### DIFF
--- a/docs/public-cloud/guest-agent.md
+++ b/docs/public-cloud/guest-agent.md
@@ -250,7 +250,7 @@ configured for TLS nor for any sort of authorization. Thus, an SSH tunnel is the
 safest route as encryption and authorization can be done through the SSH protocol.
 
 If you decide that opening guest-agent to the firewall is acceptable, you can do
-so by selecting the `Firewall` tab in your [cloud dashboard](cloud.lambdalabs.com){ .external target="_blank" }
+so by selecting the `Firewall` tab in your [cloud dashboard](https://cloud.lambdalabs.com){ .external target="_blank" }
 and adding a rule that looks like this:
 
 ![](../assets/images/guest-agent-firewall-rule.png)

--- a/docs/public-cloud/guest-agent.md
+++ b/docs/public-cloud/guest-agent.md
@@ -200,7 +200,7 @@ To set up Prometheus and Grafana:
 1. At the top-right of the dashboard, click the **+**. Then, choose **Import
    dashboard**.
 
-    ![Screenshot of how to import dashboard](../../assets/images/import-dashboard.png)
+    ![Screenshot of how to import dashboard](../assets/images/import-dashboard.png)
 
 1. In the **Import via dashboard JSON model** field, enter the
    [example JSON model](https://gist.githubusercontent.com/LandonTClipp/964e90507d660e3fb710b4137be6cd6f/raw/bc7abd797da65581534513c153d1ad3d1b8e4bbe/lambda-guest-agent-grafana-model.json){ .external target="_blank" }
@@ -215,12 +215,12 @@ To set up Prometheus and Grafana:
     - InfiniBand transfer rates
     - local storage transfer rates
 
-    ![Screenshot of an example Grafana dashboard](../../assets/images/grafana-dashboard-guest-agent.png)
+    ![Screenshot of an example Grafana dashboard](../assets/images/grafana-dashboard-guest-agent.png)
 
     !!! note
 
         On-demand instances, unlike
-        [1-Click Clusters](../1-click-clusters/index.md), don't use InfiniBand
+        [1-Click Clusters](1-click-clusters/index.md), don't use InfiniBand
         fabric. Accordingly, the InfiniBand transfer rates will always be zero.
 
 ## Security
@@ -253,7 +253,7 @@ If you decide that opening guest-agent to the firewall is acceptable, you can do
 so by selecting the `Firewall` tab in your [cloud dashboard](cloud.lambdalabs.com){ .external target="_blank" }
 and adding a rule that looks like this:
 
-![](/assets/images/guest-agent-firewall-rule.png)
+![](../assets/images/guest-agent-firewall-rule.png)
 
 ### Data Privacy
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,7 +181,6 @@ plugins:
         'on-demand-cloud/how-to-serve-the-llama-3.1-8b-and-70b-models-using-lambda-cloud-on-demand-instances.md': 'education/large-language-models/serving-llama-3-1-docker.md'
         'on-demand-cloud/deploying-models-with-dstack.md': 'education/scheduling-and-orchestration/deploying-models-with-dstack.md'
         'on-demand-cloud/file-systems.md': 'public-cloud/filesystems.md'
-        'tensorbook/getting-started.md': 'hardware/tensorbook/getting-started.md'
         'workstations/troubleshooting-workstations-and-desktops.md': 'hardware/workstations/troubleshooting.md'
         'workstations/getting-started.md': 'hardware/workstations/getting-started.md'
         'software/virtual-environments-and-docker-containers.md': 'education/programming/virtual-environments-containers.md'


### PR DESCRIPTION
This PR fixes paths that were broken when the guest agent page was moved up a level in dbb00c26757481387349e578fec35b525cf1f890 (from `/public-cloud/on-demand/` to `/public-cloud/`).

Additionally, this PR fixes a link to cloud.lambdalabs.com and removes a redirect to a non-existent page.